### PR TITLE
fix: repair pause/resume behavior

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -156,7 +156,5 @@ function mousePressed() {
 function keyPressed() {
   if (keyCode == ENTER) {
     options.pause = !options.pause;
-    console.log("No loop");
-    noLoop();
   }
 }


### PR DESCRIPTION
## Summary\n- Remove unconditional `noLoop()` from Enter pause toggle\n- Keep draw loop alive so Enter can resume simulation\n\nCloses #6\n\n## Test\n- `npx eslint sketch.js` (fails on existing repo-wide lint issues unrelated to this diff)