### PR TITLE
perf: query food with KDTree

### DIFF
--- a/kdtree.js
+++ b/kdtree.js
@@ -44,25 +44,40 @@ const KDTree = function(node, botleft, toprght, func) {
         curr_node = new Node(
             this.func(new_x),
             split,
-            [new_x],
+            new_x,
             undefined,
             undefined,
         );
-        return;
+        return curr_node;
       }
       const x_point = this.func(new_x);
       const dim = x_point.length;
-      if (x_point.equals(curr_node.point)) {
-        // Duplicate, add to values.
-        cure_node.push(new_x);
-      } else if (x_point[split] < curr_node.point[split]) {
+      if (x_point[split] < curr_node.point[split]) {
         curr_node.left = insertImpl(new_x, curr_node.left, (split + 1) % dim);
       } else {
         curr_node.right = insertImpl(new_x, curr_node.right, (split + 1) % dim);
       }
       return curr_node;
-    };
+    }.bind(this);
     this.node = insertImpl(x, this.node, 0);
+  };
+
+  this.queryRange = function(minPoint, maxPoint) {
+    const results = [];
+    const query = function(currNode) {
+      if (!currNode) return;
+
+      if (inRange(currNode.point, minPoint, maxPoint)) {
+        results.push(currNode.value);
+      }
+
+      const split = currNode.split;
+      if (minPoint[split] <= currNode.point[split]) query(currNode.left);
+      if (maxPoint[split] >= currNode.point[split]) query(currNode.right);
+    };
+
+    query(this.node);
+    return results;
   };
 };
 
@@ -79,28 +94,17 @@ function kdFromList(list, botleft, toprght, func) {
     }
 
     // Else, sort the set by split dimension
-    const sorted = sublist.sort(compareWithParam(func, split));
-    let m = floor(sorted.length / 2); // Median index
+    const sorted = sublist.slice().sort(compareWithParam(func, split));
+    const m = floor(sorted.length / 2); // Median index
     const d = sorted[m]; // Median value
-    const values = [];
-    values.push(d);
-    // gather all the same points with that value in this dimension
-    const n = 0;
-    while (
-      m + n + 1 < sorted.length &&
-      func(sorted[m + n + 1])[split] == func(d)[split]
-    ) {
-      values.push(sorted[m + n + 1]);
-      m++;
-    }
     const nextSplit = (split + 1) % func(d).length;
 
     return new Node(
         func(d),
         split,
         d,
-        makeKd(sublist.slice(0, m), nextSplit, func),
-        makeKd(sublist.slice(m + n + 1, sublist.length), nextSplit, func),
+        makeKd(sorted.slice(0, m), nextSplit, func),
+        makeKd(sorted.slice(m + 1, sorted.length), nextSplit, func),
     );
   };
   return new KDTree(makeKd(list, 0, func), botleft, toprght, func);
@@ -110,4 +114,11 @@ function compareWithParam(func, split) {
   return function(obj1, obj2) {
     return func(obj1)[split] - func(obj2)[split];
   };
+}
+
+function inRange(point, minPoint, maxPoint) {
+  for (let i = 0; i < point.length; i++) {
+    if (point[i] < minPoint[i] || point[i] > maxPoint[i]) return false;
+  }
+  return true;
 }

--- a/sketch.js
+++ b/sketch.js
@@ -60,6 +60,11 @@ function todoidalDist(locA, locB) {
   return sqrt(dx*dx + dy*dy)
 }
 
+function crossesEdge(loc, radius) {
+  return loc.x - radius < 0 || loc.x + radius > width ||
+    loc.y - radius < 0 || loc.y + radius > height;
+}
+
 /* eslint-disable-next-line no-unused-vars */
 function draw() {
   background(50);
@@ -72,6 +77,11 @@ function draw() {
     let newFood = createVector(random() * width, random() * height);
     foods.push(newFood);
   }
+
+  const foodTree = kdFromList(foods, [0, 0], [width, height], (food) => [
+    food.x,
+    food.y,
+  ]);
 
   for (let i = agents.length - 1; i >= 0; i--) {
     // Add neighbors steering behavior
@@ -102,13 +112,24 @@ function draw() {
     }
 
     let averageDir = createVector()
-    for (let j = foods.length - 1; j >= 0; j--) {
-      let dist = todoidalDist(agents[i].loc, foods[j])
+    const scanAllFood = crossesEdge(agents[i].loc, agents[i].dna.dist);
+    const candidateFoods = scanAllFood ? foods : foodTree.queryRange(
+        [agents[i].loc.x - agents[i].dna.dist,
+          agents[i].loc.y - agents[i].dna.dist],
+        [agents[i].loc.x + agents[i].dna.dist,
+          agents[i].loc.y + agents[i].dna.dist],
+    );
+    for (let j = candidateFoods.length - 1; j >= 0; j--) {
+      const food = candidateFoods[j];
+      const foodIndex = scanAllFood ? j : foods.indexOf(food);
+      if (foodIndex == -1) continue;
+
+      let dist = todoidalDist(agents[i].loc, food)
       if (dist < agents[i].dna.size) {
-        foods.splice(j, 1);
+        foods.splice(foodIndex, 1);
         agents[i].heal();
       } else if (dist < agents[i].dna.dist) {
-        averageDir.add(new p5.Vector.sub(foods[j], agents[i].loc))
+        averageDir.add(new p5.Vector.sub(food, agents[i].loc))
         // break;
       }
     }

--- a/test/kdtree.test.js
+++ b/test/kdtree.test.js
@@ -1,0 +1,40 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+function loadKDTree() {
+  const context = {floor: Math.floor};
+  vm.createContext(context);
+  vm.runInContext(
+      fs.readFileSync(path.join(__dirname, '..', 'kdtree.js'), 'utf8'),
+      context,
+  );
+  return context;
+}
+
+function byId(values) {
+  return Array.from(values, (value) => value.id).sort();
+}
+
+test('queryRange returns boundary and duplicate points', () => {
+  const {kdFromList} = loadKDTree();
+  const points = [
+    {id: 'a', x: 0, y: 0},
+    {id: 'b', x: 5, y: 5},
+    {id: 'c', x: 5, y: 5},
+    {id: 'd', x: 9, y: 9},
+  ];
+
+  const tree = kdFromList(points, [0, 0], [10, 10], (p) => [p.x, p.y]);
+
+  assert.deepEqual(byId(tree.queryRange([0, 0], [5, 5])), ['a', 'b', 'c']);
+});
+
+test('queryRange handles empty trees', () => {
+  const {kdFromList} = loadKDTree();
+  const tree = kdFromList([], [0, 0], [10, 10], (p) => [p.x, p.y]);
+
+  assert.deepEqual(Array.from(tree.queryRange([0, 0], [10, 10])), []);
+});


### PR DESCRIPTION
## Summary\n- Build a food KDTree once per frame\n- Query nearby food candidates before applying existing toroidal distance checks\n- Fall back to full scan at canvas edges to preserve wrapped-distance behavior\n\nCloses #1\n\n## Test\n- `npm test`