### PR TITLE
fix: correct dna mutation bounds

### DIFF
--- a/dna.js
+++ b/dna.js
@@ -1,9 +1,15 @@
 const mutation_rate = 0.1;
+const minSize = 10;
+const maxSize = 50;
+const minMove = 1;
+const maxMove = 100;
+const minDist = 50;
+const maxDist = 500;
 
 function DNA(
-    size = random(10, 50),
-    move = random(1, 100),
-    dist = random(50, 500),
+    size = random(minSize, maxSize),
+    move = random(minMove, maxMove),
+    dist = random(minDist, maxDist),
 ) {
   this.size = size;
   this.move = move;
@@ -25,7 +31,7 @@ function combine(dna1, dna2) {
 
   // size combine or mutate
   if (random() < mutation_rate) {
-    newSize = random(5, 50);
+    newSize = random(minSize, maxSize);
   } else {
     // average 1 and 2
     newSize = (dna1.size + dna2.size) / 2;
@@ -33,7 +39,7 @@ function combine(dna1, dna2) {
 
   // move combine or mutate
   if (random() < mutation_rate) {
-    newMove = random(1, 100);
+    newMove = random(minMove, maxMove);
   } else {
     // average 1 and 2
     newMove = (dna1.move + dna2.move) / 2;
@@ -41,7 +47,7 @@ function combine(dna1, dna2) {
 
   // dist combine or mutate
   if (random() < mutation_rate) {
-    newDist = random(50, 500);
+    newDist = random(minDist, maxDist);
   } else {
     // average 1 and 2
     newDist = (dna1.dist + dna2.dist) / 2;

--- a/test/dna.test.js
+++ b/test/dna.test.js
@@ -14,19 +14,53 @@ function loadDNA(random = () => 0.5) {
   return context;
 }
 
-test('DNA.equals compares move', () => {
+test('DNA.equals compares every gene', () => {
   const {DNA} = loadDNA();
   const dna = new DNA(10, 20, 30);
 
   assert.equal(dna.equals(new DNA(10, 20, 30)), true);
+  assert.equal(dna.equals(new DNA(11, 20, 30)), false);
   assert.equal(dna.equals(new DNA(10, 21, 30)), false);
+  assert.equal(dna.equals(new DNA(10, 20, 31)), false);
 });
 
 test('combine averages genes when mutation does not happen', () => {
-  const {DNA, combine} = loadDNA();
+  const context = loadDNA();
+  const {DNA, combine} = context;
   const child = combine(new DNA(10, 20, 30), new DNA(20, 40, 50));
 
   assert.equal(child.size, 15);
   assert.equal(child.move, 30);
   assert.equal(child.dist, 40);
+  assert.equal('newSize' in context, false);
+  assert.equal('newMove' in context, false);
+  assert.equal('newDist' in context, false);
+});
+
+test('default DNA and mutations use the same gene bounds', () => {
+  const calls = [];
+  const values = [10, 1, 50, 0, 12, 0, 34, 0, 56];
+  const {DNA, combine} = loadDNA((min, max) => {
+    calls.push([min, max]);
+    return values.shift();
+  });
+
+  new DNA();
+  const child = combine(new DNA(10, 20, 30), new DNA(20, 40, 50));
+
+  assert.deepEqual(calls, [
+    [10, 50],
+    [1, 100],
+    [50, 500],
+    [undefined, undefined],
+    [10, 50],
+    [undefined, undefined],
+    [1, 100],
+    [undefined, undefined],
+    [50, 500],
+  ]);
+  assert.deepEqual(
+      {size: child.size, move: child.move, dist: child.dist},
+      {size: 12, move: 34, dist: 56},
+  );
 });


### PR DESCRIPTION
## Summary
- Reuse one set of DNA gene bounds for default construction and mutation
- Align size mutation bounds with constructor bounds
- Expand DNA regression tests for equality, combine locals, and mutation bounds

Closes #7

## Tests
- npm test
- npx eslint test/dna.test.js
- npx eslint dna.js (fails on pre-existing mutation_rate camelcase and combine no-unused-vars)